### PR TITLE
Fix for Module is imported with 'import' and 'import from'

### DIFF
--- a/tests/operations/test_optimize_images_complete.py
+++ b/tests/operations/test_optimize_images_complete.py
@@ -6,8 +6,8 @@ import pytest
 
 from pdftl.exceptions import InvalidArgumentError, PackageError
 
-# Import the logic functions directly for easier testing
-from pdftl.operations.optimize_images import _parse_args_to_options, optimize_images_pdf
+# Import the optimize_images module for testing
+import pdftl.operations.optimize_images as optimize_images_module
 
 # --- 1. Parameter Parsing Tests (Lines 207-278) ---
 
@@ -15,41 +15,41 @@ from pdftl.operations.optimize_images import _parse_args_to_options, optimize_im
 def test_optimize_args_keywords():
     """Test standard keyword aliases."""
     # optimize, jpeg, png, jbig2, jobs
-    assert _parse_args_to_options(["low"]) == (1, 0, 0, False, 0)
-    assert _parse_args_to_options(["medium"]) == (2, 0, 0, False, 0)
-    assert _parse_args_to_options(["high"]) == (3, 0, 0, False, 0)
+    assert optimize_images_module._parse_args_to_options(["low"]) == (1, 0, 0, False, 0)
+    assert optimize_images_module._parse_args_to_options(["medium"]) == (2, 0, 0, False, 0)
+    assert optimize_images_module._parse_args_to_options(["high"]) == (3, 0, 0, False, 0)
     # 'all' implies max optimize + jbig2
-    assert _parse_args_to_options(["all"]) == (3, 0, 0, True, 0)
+    assert optimize_images_module._parse_args_to_options(["all"]) == (3, 0, 0, True, 0)
 
 
 def test_optimize_args_jbig2_alias():
     """Test JBIG2 aliases (Lines 227-228)."""
     # jbig2_lossy sets boolean to True, leaves optimize at default (2)
-    assert _parse_args_to_options(["jbig2_lossy"]) == (2, 0, 0, True, 0)
-    assert _parse_args_to_options(["jb2lossy"]) == (2, 0, 0, True, 0)
+    assert optimize_images_module._parse_args_to_options(["jbig2_lossy"]) == (2, 0, 0, True, 0)
+    assert optimize_images_module._parse_args_to_options(["jb2lossy"]) == (2, 0, 0, True, 0)
 
 
 def test_optimize_args_quality_specific():
     """Test specific jpeg/png quality flags (Lines 239, etc)."""
     # jpeg_quality
-    opts = _parse_args_to_options(["jpeg_quality=50"])
+    opts = optimize_images_module._parse_args_to_options(["jpeg_quality=50"])
     assert opts[1] == 50
     # png_quality (Line 239)
-    opts = _parse_args_to_options(["png_quality=60"])
+    opts = optimize_images_module._parse_args_to_options(["png_quality=60"])
     assert opts[2] == 60
 
 
 def test_optimize_args_quality_general():
     """Test generic 'quality' flag (Lines 241-242)."""
     # Should set both JPEG and PNG
-    opts = _parse_args_to_options(["quality=75"])
+    opts = optimize_images_module._parse_args_to_options(["quality=75"])
     assert opts[1] == 75
     assert opts[2] == 75
 
 
 def test_optimize_args_jobs():
     """Test jobs flag."""
-    opts = _parse_args_to_options(["jobs=4"])
+    opts = optimize_images_module._parse_args_to_options(["jobs=4"])
     assert opts[4] == 4
 
 
@@ -57,23 +57,23 @@ def test_optimize_args_errors():
     """Test invalid inputs (Lines 266, 270)."""
     # 1. Invalid Key (Line 270)
     with pytest.raises(InvalidArgumentError, match="Unrecognized keyword"):
-        _parse_args_to_options(["not_a_valid_flag=10"])
+        optimize_images_module._parse_args_to_options(["not_a_valid_flag=10"])
 
     # 2. Invalid Key Value (Garbage)
     with pytest.raises(InvalidArgumentError, match="Unrecognized keyword"):
-        _parse_args_to_options(["garbage"])
+        optimize_images_module._parse_args_to_options(["garbage"])
 
     # 3. Negative Jobs (Line 266)
     with pytest.raises(InvalidArgumentError, match="cannot be negative"):
-        _parse_args_to_options(["jobs=-1"])
+        optimize_images_module._parse_args_to_options(["jobs=-1"])
 
     # 4. Invalid Quality Range
     with pytest.raises(InvalidArgumentError, match="integer between 0 and 100"):
-        _parse_args_to_options(["quality=150"])
+        optimize_images_module._parse_args_to_options(["quality=150"])
 
     # 5. Non-integer value
     with pytest.raises(InvalidArgumentError, match="Could not convert"):
-        _parse_args_to_options(["quality=high"])
+        optimize_images_module._parse_args_to_options(["quality=high"])
 
 
 # --- 2. Import Error Logic (Lines 35-40, 125-130) ---
@@ -90,7 +90,7 @@ def test_optimize_images_import_failure():
 
         # The assertion: Does calling the function raise the expected error?
         with pytest.raises(PackageError, match="Loading OCRmyPDF failed"):
-            optimize_images_pdf(mock_pdf, [], "dummy_out.pdf")
+            optimize_images_module.optimize_images_pdf(mock_pdf, [], "dummy_out.pdf")
 
 
 # --- 3. Success Logic (Mocked) ---
@@ -105,15 +105,13 @@ def test_optimize_images_success(two_page_pdf):
 
     with patch.dict(sys.modules, {"ocrmypdf": MagicMock(), "ocrmypdf.optimize": mock_lib}):
         # Reload to hit the 'try' block successfully
-        import pdftl.operations.optimize_images
-
-        importlib.reload(pdftl.operations.optimize_images)
+        importlib.reload(optimize_images_module)
 
         import pikepdf
 
         with pikepdf.open(two_page_pdf) as pdf:
             # Call the function (args: pdf, operation_args, output_filename)
-            pdftl.operations.optimize_images.optimize_images_pdf(pdf, ["medium"], "out.pdf")
+            optimize_images_module.optimize_images_pdf(pdf, ["medium"], "out.pdf")
 
             # Check that it called the library functions
             mock_lib.extract_images_generic.assert_called()


### PR DESCRIPTION
In general, to fix this issue you should avoid importing the same module using both `import ...` and `from ... import ...` in a single file. Instead, choose one style and use it consistently. In this case, the cleanest fix is to import the module once as a module object and then reference its attributes (functions) through that module, which also works naturally with `importlib.reload`.

Concretely for `tests/operations/test_optimize_images_complete.py`, replace the line:

- `from pdftl.operations.optimize_images import _parse_args_to_options, optimize_images_pdf`

with a single module import such as:

- `import pdftl.operations.optimize_images as optimize_images_module`

Then update all uses:

- `_parse_args_to_options(...)` → `optimize_images_module._parse_args_to_options(...)`
- `optimize_images_pdf(...)` → `optimize_images_module.optimize_images_pdf(...)`

In `test_optimize_images_success`, we can then reuse this same module object for reloading, instead of doing a second `import pdftl.operations.optimize_images`. Replace that `import` with an assignment from `sys.modules` after reloading, or directly reload `optimize_images_module`. This removes the mixed import forms while preserving the intended reload behavior and function calls. All changes are within `tests/operations/test_optimize_images_complete.py`, touching the initial imports and the references to the imported names.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._