### PR TITLE
Fix for Module is imported with 'import' and 'import from'

### DIFF
--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -262,11 +262,11 @@ def test_main_execution_block():
     """Triggers line 180: The __main__ block (via manual import/execution)."""
     with patch("pdftl.cli.main.main") as mock_main:
         # This simulates the behavior of running the script directly
-        import pdftl.cli.main as cli_main
+        import pdftl.cli.main as main_module
 
         # We can't easily trigger the actual __name__ check without a subprocess,
         # but calling the logic at that level or mocking the entry point is standard.
-        if hasattr(cli_main, "__name__") and cli_main.__name__ == "pdftl.cli.main":
+        if hasattr(main_module, "__name__") and main_module.__name__ == "pdftl.cli.main":
             pass  # Logic verified by structure
 
 


### PR DESCRIPTION
In general, to fix “import” vs “import from” conflicts, choose a consistent pattern or at least avoid using the same alias for different imported objects from the same module. Within a single file, do not have `from pdftl.cli.main import main as cli_main` and later `import pdftl.cli.main as cli_main`, as that makes `cli_main` ambiguous.

The best minimal fix here is to rename the alias used for the module import at line 265 so it no longer conflicts with the earlier `cli_main` function alias imported at line 11. For example, change `import pdftl.cli.main as cli_main` to `import pdftl.cli.main as main_module` (or another unique name), and update the subsequent references in that test to use the new alias. This keeps all functionality and test intent the same while resolving the CodeQL warning and eliminating the confusing alias reuse. No new imports or external packages are needed; only the alias and its uses inside `test_main_execution_block` need to be updated.

Concretely:
- In tests/cli/test_main.py, locate the block starting at line 261 (`def test_main_execution_block`).
- Change `import pdftl.cli.main as cli_main` to `import pdftl.cli.main as main_module` (or similar).
- Update the condition at line 269 to reference `main_module` instead of `cli_main`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._